### PR TITLE
Add menu layout option

### DIFF
--- a/src/classes/ahpClasses.js
+++ b/src/classes/ahpClasses.js
@@ -1759,6 +1759,7 @@ class PieMenu {
             backgroundColor: [35,35,35,255],
             selectionColor: [30,232,226,255],
             fontColor: [255,255,255,255],
+            layout: "radial",
             radius: 20,
             thickness: 10,
             labelRadius: 80,

--- a/src/createNewPieMenu.js
+++ b/src/createNewPieMenu.js
@@ -7,6 +7,7 @@ var newPieMenu = {
     activationModeValidationWarning: $('#activation-mode-validation-warning'),
     selectionColorInput: $('#new-selection-color-input')[0].jscolor,    
     backgroundColorInput: $('#new-background-color-input')[0].jscolor,
+    layoutSelect: document.getElementById('new-menu-layout-select'),
     cancelBtn: document.getElementById('new-pie-menu-cancel-btn'),
     createBtn: document.getElementById('new-pie-menu-create-btn'),
     backBtn: document.getElementById('new-pie-menu-back-btn'),
@@ -38,11 +39,14 @@ var newPieMenu = {
         this.selectionColorInput.onChange = function(){
             newPieMenu.newPieKeyObj.pieMenus[0].selectionColor = hexToRgb(this.toHEXString());                        
         };
-        this.backgroundColorInput.onChange = function(){            
+        this.backgroundColorInput.onChange = function(){
             newPieMenu.newPieKeyObj.pieMenus.forEach((pieMenu) => {
                 pieMenu.backgroundColor = hexToRgb(this.toHEXString());
-            });                       
+            });
         };
+        this.layoutSelect.addEventListener('change', function(event){
+            newPieMenu.newPieKeyObj.pieMenus.forEach((pieMenu) => {pieMenu.layout = event.target.value});
+        });
         this.pieMenuNameField.addEventListener("change", function(event){
             newPieMenu.newPieKeyObj.name = event.target.value;            
         });
@@ -95,6 +99,7 @@ var newPieMenu = {
         this.pieKeyBtn.innerHTML = "Choose Keystroke...";        
         this.selectionColorInput.processValueInput(rgbToHex(np.newPieKeyObj.pieMenus[0].selectionColor));
         this.backgroundColorInput.processValueInput(rgbToHex(np.newPieKeyObj.pieMenus[0].backgroundColor));
+        this.layoutSelect.value = np.newPieKeyObj.pieMenus[0].layout;
     }
 }
 
@@ -130,7 +135,8 @@ async function createNewPieMenu(options={}){
                 selectionColor: copyMenu.pieMenus[0].selectionColor,
                 radius:copyMenu.pieMenus[0].radius,
                 thickness:copyMenu.pieMenus[0].thickness,
-                labelRadius: copyMenu.pieMenus[0].labelRadius,                
+                labelRadius: copyMenu.pieMenus[0].labelRadius,
+                layout: copyMenu.pieMenus[0].layout,
                 pieAngle: 22.5,
                 functions: PieFunction.fill(9)
             })]

--- a/src/editPieMenu.js
+++ b/src/editPieMenu.js
@@ -724,7 +724,8 @@ var editPieMenu = {
                 let selectedPieMenu = editPieMenu.selectedPieMenu
                 let selectedSlice = editPieMenu.selectedSlice
                 let disp = editPieMenu.pieMenuDisplay
-                
+                let isGridLayout = (selectedPieMenu.layout === 'grid');
+
                 let c = document.getElementById('pie-menu-center');
                 let cFG = document.getElementById('pie-menu-foreground');
                 let ctx = c.getContext("2d");
@@ -735,7 +736,12 @@ var editPieMenu = {
                 
 
                 // let bounds = [window.innerWidth, window.innerHeight];
-                let bounds = [window.innerWidth, Math.max(selectedPieMenu.radius+selectedPieMenu.labelRadius+200,400)];  //FIX ME
+                let bounds;
+                if(isGridLayout){
+                    bounds = [window.innerWidth, 400];
+                }else{
+                    bounds = [window.innerWidth, Math.max(selectedPieMenu.radius+selectedPieMenu.labelRadius+200,400)];  //FIX ME
+                }
                 c.width = bounds[0]
                 c.height = bounds[1]          
                 cFG.width = bounds[0]
@@ -794,9 +800,11 @@ var editPieMenu = {
 
                     let selectedSlicePosition;
                     
-                    if(element.type == "pieCircle"){                        
-                        //draw circle and set region
-                        disp.draw.pieCircle(element, centerPos);
+                    if(element.type == "pieCircle"){
+                        if(!isGridLayout){
+                            //draw circle and set region
+                            disp.draw.pieCircle(element, centerPos);
+                        }
                     }
                     else if(element.type == "sliceLabel" && element.isDragging == false){
                         let isSelected = element.isSelected;
@@ -1171,12 +1179,18 @@ var editPieMenu = {
                 editPieMenu.pieMenuDisplay.refresh();
             });
 
-            this.mainMenu.labelRoundnessSlider.on('mousedown mousemove change', (event) => {                         
-                let newValue = handleSliderDiv(event);                
+            this.mainMenu.labelRoundnessSlider.on('mousedown mousemove change', (event) => {
+                let newValue = handleSliderDiv(event);
                 // (typeof(newValue) === 'number') && (editPieMenu.selectedPieMenu.labelRoundness = newValue)
                 if (typeof(newValue) === 'number') {
                     editPieMenu.selectedPieKey.pieMenus.forEach((pieMenu) => {pieMenu.labelRoundness = newValue})
-                }        
+                }
+                editPieMenu.pieMenuDisplay.refresh();
+            });
+
+            // Menu Layout select
+            $('#menu-layout-select').on('change', (event) => {
+                editPieMenu.selectedPieMenu.layout = event.target.value;
                 editPieMenu.pieMenuDisplay.refresh();
             });
 
@@ -1312,6 +1326,7 @@ var editPieMenu = {
                 setSliderDivValue(this.mainMenu.labelRoundnessSlider,selectedPieMenu.labelRoundness,0,100);
                 editPieMenu.selectedPieKey.pieMenus.forEach( (pieMenu) => {pieMenu.labelRoundness = editPieMenu.selectedPieKey.pieMenus[0].labelRoundness});
                 setSliderDivValue(this.mainMenu.labelDelaySlider,editPieMenu.selectedPieKey.labelDelay,0,50,1);
+                $('#menu-layout-select').val(selectedPieMenu.layout);
             }else{
                 if(editPieMenu.selectedPieMenu.pieAngle != 0){
                     $('#sub-angle-offset-btncheck1').prop('checked', false)
@@ -1331,6 +1346,7 @@ var editPieMenu = {
                 } else {
                     this.subMenu.backFunctionCheckBox.checked = false                    
                 }
+                $("#menu-layout-select").val(selectedPieMenu.layout);
             }  
         },
         refreshPieAngle(setIsOffset=null){

--- a/src/index.html
+++ b/src/index.html
@@ -249,6 +249,12 @@
                                                 <p style="margin-right: 14px;margin-bottom: 3px;width: 194.8281px;">Label Roundness:</p><input class="form-range" type="range" style="margin-right: 15px;"><input class="bg-dark border rounded-0 border-dark" type="text" style="font-size: 16px;color: var(--bs-white);width: 40px;text-align: center;" placeholder="20" maxlength="3" inputmode="numeric">
                                             </div>
                                             <div class="d-flex align-items-center" style="margin-bottom: 9px;">
+                                                <p style="margin-right: 14px;margin-bottom: 3px;">Layout:</p><select id="menu-layout-select" class="form-select" style="height: 38px;max-width: 143px;">
+                                                    <option value="radial" selected="">Radial</option>
+                                                    <option value="grid">Grid</option>
+                                                </select>
+                                            </div>
+                                            <div class="d-flex align-items-center" style="margin-bottom: 9px;">
                                                 <p style="margin-right: 14px;margin-bottom: 3px;">Angle:</p><div id="main-angle-offset-btn-group" class="btn-group" role="group" aria-label="Basic checkbox toggle button group">
     <input type="checkbox" name="none" class="btn-check" id="main-angle-offset-btncheck1" checked="" autocomplete="off">
     <label class="btn btn-outline-primary" name="none" for="main-angle-offset-btncheck1">None</label>
@@ -603,6 +609,15 @@
                             <div class="d-flex align-items-center">
                                 <h5 class="d-xxl-flex align-items-xxl-center" style="margin-bottom: -10px;margin-right: 15px;margin-top: -11px;">Background Color:</h5>
                             </div><input class="form-control" type="text" id="new-background-color-input" data-jscolor="" value="" style="width: 143px;">
+                        </div>
+                        <div class="d-flex justify-content-start" style="padding-top: 12px;padding-bottom: 12px;">
+                            <div class="d-flex align-items-center"></div>
+                            <div class="d-flex align-items-center">
+                                <h5 class="d-xxl-flex align-items-xxl-center" style="margin-bottom: -10px;margin-right: 15px;margin-top: -11px;">Layout:</h5>
+                            </div><select id="new-menu-layout-select" class="form-select" style="width: 143px;">
+                                <option value="radial" selected="">Radial</option>
+                                <option value="grid">Grid</option>
+                            </select>
                         </div>
                         <div class="d-flex justify-content-center" style="padding-top: 12px;padding-bottom: 12px;margin-top: 15px;">
                             <div class="d-flex align-items-center"></div>


### PR DESCRIPTION
## Summary
- add `layout` property to `PieMenu`
- add layout selection controls to the UI
- wire up new option when creating or editing menus

## Testing
- `npm run build` *(fails: Cannot find module buildrefreshIndexScripts.js)*

------
https://chatgpt.com/codex/tasks/task_e_68735f8be37c832dbc875dd41f53c353