### PR TITLE
Add global toggle hotkey

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ Some macro mice don't send their key_up events when their key is released (Logit
 
 In order to activate a pie menu with a pen button, go into your pen software and set a key to send '4th click / Forward' or '5th Click / Back'. You may use any other key, but other keys may not send their 'key-up' signal when the pen button is released. You can then set the Pie menu key to respond to '4th click / Forward' or '5th Click / Back' in the 'Special Keys' menu.
 
+### Toggling AutoHotPie
+
+Press **F12** at any time to temporarily disable all AutoHotPie hotkeys. Press **F12** again to re-enable them. This lets you use the original keyboard shortcuts without quitting the application.
+
 ### External controllers or Remotes
 
 Most bluetooth controllers can have their buttons assigned to a keystroke in their software, however most do not send their 'key-up' signal when their button is released. To handle this, use the 'Hover over all selections' launch mode. The pie menu will stay open after the button is pressed, and selections can be hovered over to be selected.

--- a/src/PieMenu.ahk
+++ b/src/PieMenu.ahk
@@ -61,6 +61,8 @@ global SliceHotkey
 SliceHotkey.pressed := false
 global ExitKey
 ExitKey.pressed := false
+; global toggle state for suspending all hotkeys
+global AppSuspended := false
 
 ; global pieDPIScale
 getMonitorCoords(Mon.left , Mon.right , Mon.top , Mon.bottom )
@@ -70,6 +72,13 @@ SetUpGDIP(0, 0, 50, 50) ;windows were appearing over taskbar without -0.01
 SetUpGDIP(0, 0, 0, 0) ; To Fix white box in screenshare (https://github.com/dumbeau/AutoHotPie/issues/115)
 
 verifyFont()
+
+; Hotkey to toggle AutoHotPie on/off. Default: F12
+F12::
+    AppSuspended := !AppSuspended
+    Suspend, % AppSuspended ? "On" : "Off"
+    TrayTip, AutoHotPie, % AppSuspended ? "Hotkeys Disabled" : "Hotkeys Enabled", 1
+return
 
 ;Set up icon menu tray options
 if (A_IsCompiled){


### PR DESCRIPTION
## Summary
- let F12 suspend or resume AutoHotPie hotkeys
- document the new toggle hotkey in README

## Testing
- `node build/refreshIndexScripts.js`


------
https://chatgpt.com/codex/tasks/task_e_6874c6fce5d0832d9760376856cc32c3