### PR TITLE
Add key switcher option

### DIFF
--- a/src/PieMenu.ahk
+++ b/src/PieMenu.ahk
@@ -181,9 +181,14 @@ onPieLabel:
 return
 
 offPieLabel:
-	pieEnableKey.modOff()
+        pieEnableKey.modOff()
 ; msgbox, ActiveProfile
 ; msgbox, off
+return
+
+switcherLabel:
+        Suspend, Permit
+        Suspend, Toggle
 return
 
 blockLabel:

--- a/src/classes/ahpClasses.js
+++ b/src/classes/ahpClasses.js
@@ -1707,7 +1707,8 @@ class AppProfile {
                 useEnableKey: false,
                 enableKey: "capslock",
                 toggle: false,
-                sendOriginalFunc: false          
+                sendOriginalFunc: false,
+                keySwitcher: false
             },
             pieKeys: []            
         };

--- a/src/index.html
+++ b/src/index.html
@@ -101,6 +101,7 @@
                                     <div class="form-check"><input class="form-check-input" type="radio" id="pie-enable-key-radio-hold" name="toggleMode" checked=""><label class="form-check-label" for="formCheck-1">Enable menus when key is held</label></div>
                                     <div class="form-check" id="send-original-key-checkbox-div" style="padding-left: 49px;"><input class="form-check-input" type="checkbox" id="send-original-key-checkbox-input"><label class="form-check-label" for="formCheck-2">Send original key's function if no menu is ran</label></div>
                                     <div class="form-check"><input class="form-check-input" type="radio" id="pie-enable-key-radio-toggle" name="toggleMode"><label class="form-check-label" for="formCheck-1">Toggle menus when key is pressed</label></div>
+                                    <div class="form-check"><input class="form-check-input" type="radio" id="pie-enable-key-radio-switcher" name="toggleMode"><label class="form-check-label" for="formCheck-1">Key Switcher</label></div>
                                 </div>
                             </div>
                             <div id="assigned-programs-div" style="border: 1px solid var(--bs-gray);padding: 24px;border-radius: 14px;width: 50%;margin: 13px;">
@@ -1138,25 +1139,25 @@
     <script src="assets/bootstrap/js/bootstrap.min.js"></script>
     <script src="assets/js/bs-init.js"></script>
     <!-- UPDATED ON COMPILE -->
-<script src="./lib\jscolor.js"></script>
-<script src="./lib\renderer.js"></script>
-<script src="./classes\ahpClasses.js"></script>
-<script src="./changeActivationMode.js"></script>
-<script src="./confirmation.js"></script>
-<script src="./createNewPieMenu.js"></script>
-<script src="./createNewProfile.js"></script>
-<script src="./createNewScript.js"></script>
-<script src="./editPieMenu.js"></script>
-<script src="./editScript.js"></script>
-<script src="./errorPage.js"></script>
-<script src="./exitConfirm.js"></script>
-<script src="./functionSelect.js"></script>
-<script src="./hotkeyManagement.js"></script>
-<script src="./iconManager.js"></script>
-<script src="./menuFunctions.js"></script>
-<script src="./profileManagement.js"></script>
-<script src="./runningPieMenu.js"></script>
-<script src="./initializePages.js"></script>
+<script src="./src/lib/jscolor.js"></script>
+<script src="./src/lib/renderer.js"></script>
+<script src="./src/classes/ahpClasses.js"></script>
+<script src="./src/changeActivationMode.js"></script>
+<script src="./src/confirmation.js"></script>
+<script src="./src/createNewPieMenu.js"></script>
+<script src="./src/createNewProfile.js"></script>
+<script src="./src/createNewScript.js"></script>
+<script src="./src/editPieMenu.js"></script>
+<script src="./src/editScript.js"></script>
+<script src="./src/errorPage.js"></script>
+<script src="./src/exitConfirm.js"></script>
+<script src="./src/functionSelect.js"></script>
+<script src="./src/hotkeyManagement.js"></script>
+<script src="./src/iconManager.js"></script>
+<script src="./src/menuFunctions.js"></script>
+<script src="./src/profileManagement.js"></script>
+<script src="./src/runningPieMenu.js"></script>
+<script src="./src/initializePages.js"></script>
 <!-- END OF UPDATED ON COMPILE -->
 </body>
 

--- a/src/lib/BGFunks.ahk
+++ b/src/lib/BGFunks.ahk
@@ -226,19 +226,23 @@ loadPieMenus(){
 					Try Hotkey, % pieKey.hotkey, Off
 					}
 				}			
-			If (profile.pieEnableKey.useEnableKey == true)
-				{
-					If (profile.pieEnableKey.toggle == true)
-						{					
-						Hotkey, % profile.pieEnableKey.enableKey, togglePieLabel				
-						}
-					else
-						{
-						Hotkey, % profile.pieEnableKey.enableKey, onPieLabel
-						upHotkey := profile.pieEnableKey.enableKey " up"
-						Hotkey, % upHotkey, offPieLabel
-						}
-				}
+                                If (profile.pieEnableKey.useEnableKey == true)
+                                {
+                                        If (profile.pieEnableKey.keySwitcher == true)
+                                                {
+                                                Hotkey, % profile.pieEnableKey.enableKey, switcherLabel
+                                                }
+                                        else If (profile.pieEnableKey.toggle == true)
+                                                {
+                                                Hotkey, % profile.pieEnableKey.enableKey, togglePieLabel
+                                                }
+                                        else
+                                                {
+                                                Hotkey, % profile.pieEnableKey.enableKey, onPieLabel
+                                                upHotkey := profile.pieEnableKey.enableKey " up"
+                                                Hotkey, % upHotkey, offPieLabel
+                                                }
+                                }
 		}
 	}
 
@@ -262,19 +266,23 @@ loadPieMenus(){
 					Try Hotkey, % pieKey.hotkey, Off
 					}
 				}			
-			If (profile.pieEnableKey.useEnableKey == true)
-				{
-				If (profile.pieEnableKey.toggle == true)
-					{					
-					Hotkey, % profile.pieEnableKey.enableKey, togglePieLabel				
-					}
-				else
-					{
-					Hotkey, % profile.pieEnableKey.enableKey, onPieLabel
-					upHotkey := profile.pieEnableKey.enableKey " up"
-					Hotkey, % upHotkey, offPieLabel
-					}
-				}
+                                If (profile.pieEnableKey.useEnableKey == true)
+                                {
+                                If (profile.pieEnableKey.keySwitcher == true)
+                                        {
+                                        Hotkey, % profile.pieEnableKey.enableKey, switcherLabel
+                                        }
+                                else If (profile.pieEnableKey.toggle == true)
+                                        {
+                                        Hotkey, % profile.pieEnableKey.enableKey, togglePieLabel
+                                        }
+                                else
+                                        {
+                                        Hotkey, % profile.pieEnableKey.enableKey, onPieLabel
+                                        upHotkey := profile.pieEnableKey.enableKey " up"
+                                        Hotkey, % upHotkey, offPieLabel
+                                        }
+                                }
         }
 		else                                                ;app specific context
 		{
@@ -297,19 +305,23 @@ loadPieMenus(){
 						Try Hotkey, % pieKey.hotkey, Off
 						}
 					}			
-				If (profile.pieEnableKey.useEnableKey == true)
-					{
-					If (profile.pieEnableKey.toggle == true)
-						{
-							Try Hotkey, % profile.pieEnableKey.enableKey, togglePieLabel				
-						}
-					else
-						{
-						Try Hotkey, % profile.pieEnableKey.enableKey, onPieLabel
-						upHotkey := profile.pieEnableKey.enableKey " up"
-						Try Hotkey, % upHotkey, offPieLabel
-						}
-					}
+                                If (profile.pieEnableKey.useEnableKey == true)
+                                        {
+                                        If (profile.pieEnableKey.keySwitcher == true)
+                                                {
+                                                        Try Hotkey, % profile.pieEnableKey.enableKey, switcherLabel
+                                                }
+                                        else If (profile.pieEnableKey.toggle == true)
+                                                {
+                                                        Try Hotkey, % profile.pieEnableKey.enableKey, togglePieLabel
+                                                }
+                                        else
+                                                {
+                                                Try Hotkey, % profile.pieEnableKey.enableKey, onPieLabel
+                                                upHotkey := profile.pieEnableKey.enableKey " up"
+                                                Try Hotkey, % upHotkey, offPieLabel
+                                                }
+                                        }
 			}			          
         }
 					

--- a/src/profileManagement.js
+++ b/src/profileManagement.js
@@ -142,7 +142,8 @@ var profileManagement = {
             this.addPieEnableKeyModeRadioHoldListener()
             this.addPieEnableKeyModeRadioHoldListener()
             this.addPieEnableKeyModeRadioToggleListener()
-            this.addMoreSettingsListener();  
+            this.addPieEnableKeyModeRadioSwitcherListener()
+            this.addMoreSettingsListener();
             this.addPieEnableKeySendOriginalFuncListener();  
             $('#less-profile-settings-btn-text').toggle();                
             $('#more-profile-settings-div').toggle();                                       
@@ -166,10 +167,11 @@ var profileManagement = {
             }
             
             this.keyBtn.html(new Hotkey(selectedPieEnableKey.enableKey).displayKey);
-            this.modeRadioHold.checked = !(selectedPieEnableKey.toggle);
+            this.modeRadioHold.checked = !(selectedPieEnableKey.toggle || selectedPieEnableKey.keySwitcher);
             this.modeRadioToggle.checked = selectedPieEnableKey.toggle;
+            this.modeRadioSwitcher.checked = selectedPieEnableKey.keySwitcher;
             this.sendOriginalFuncCheckbox.prop('checked', selectedPieEnableKey.sendOriginalFunc);
-            if (selectedPieEnableKey.toggle == false){                
+            if (selectedPieEnableKey.toggle == false && !selectedPieEnableKey.keySwitcher){
                 this.sendOriginalFuncDiv.show();
             } else {
                 this.sendOriginalFuncDiv.hide();
@@ -215,11 +217,20 @@ var profileManagement = {
             })
         },
         modeRadioToggle: document.getElementById("pie-enable-key-radio-toggle"),
-        addPieEnableKeyModeRadioToggleListener:function(){            
+        addPieEnableKeyModeRadioToggleListener:function(){
             this.modeRadioToggle.addEventListener("click", function(event){
                 profileManagement.selectedProfile.pieEnableKey.toggle = true;
-                profileManagement.pieEnableKey.updateUIControls();    
-            })                   
+                profileManagement.selectedProfile.pieEnableKey.keySwitcher = false;
+                profileManagement.pieEnableKey.updateUIControls();
+            })
+        },
+        modeRadioSwitcher: document.getElementById("pie-enable-key-radio-switcher"),
+        addPieEnableKeyModeRadioSwitcherListener:function(){
+            this.modeRadioSwitcher.addEventListener("click", function(event){
+                profileManagement.selectedProfile.pieEnableKey.keySwitcher = true;
+                profileManagement.selectedProfile.pieEnableKey.toggle = false;
+                profileManagement.pieEnableKey.updateUIControls();
+            })
         },
         sendOriginalFuncDiv: $('#send-original-key-checkbox-div'),
         sendOriginalFuncCheckbox: $('#send-original-key-checkbox-input'),


### PR DESCRIPTION
## Summary
- add `keySwitcher` option to profile enable key settings
- update settings UI for new radio button
- toggle pie menus globally when key switcher is used
- support switcher behavior in AHK scripts

## Testing
- `node build/refreshIndexScripts.js`

------
https://chatgpt.com/codex/tasks/task_e_687ca952a7f0832dabcad2b74ead969c